### PR TITLE
Update async-runner.js

### DIFF
--- a/lib/async-runner.js
+++ b/lib/async-runner.js
@@ -11,7 +11,7 @@ class AsyncRunner extends EventEmitter {
         this.index = 0;
         this.completed = 0;
         this.options = {
-            maxThreads: opts.maxThreads || 1,
+            maxThreads: opts.maxThreads || 10,
             stopOnError: opts.stopOnError || false,
         };
     }


### PR DESCRIPTION
Docs fix: Default threads is 10 (was set to 1)